### PR TITLE
Fixed Not.to_be_an_error_like

### DIFF
--- a/preggy/assertions/types/errors.py
+++ b/preggy/assertions/types/errors.py
@@ -39,3 +39,13 @@ def to_have_an_error_message_of(topic, expected):
 def to_be_an_error(topic):
     '''Asserts that `topic` is an error.'''
     return isinstance(topic, BaseException)
+
+
+@assertion
+def not_to_be_an_error_like(topic, expected):
+    '''Asserts that `topic` not is an instance (or subclass) of type `expected`.'''
+    if isinstance(topic, expected):
+        msg = 'Expected topic({0}) not to be an error of type {1}, but it was a {2}'
+        values = topic, expected, topic.__class__
+        err = AssertionError(msg.format(*values), *values)
+        raise err

--- a/tests/types/test_errors.py
+++ b/tests/types/test_errors.py
@@ -17,7 +17,7 @@ from preggy import expect
 
 
 def test_is_error():
-    topic = RuntimeError('Something Wrong') 
+    topic = RuntimeError('Something Wrong')
     expect(topic).to_be_an_error()
     expect(topic).to_be_an_error_like(RuntimeError)
     expect(topic).to_have_an_error_message_of('Something Wrong')
@@ -69,13 +69,18 @@ def test_error_messages():
         expect(err).to_have_an_error_message_of('Expected topic(2) to be an error')
     
 
-def test_not_to_be_an_error_like():
+
+def test_to_be_an_error_like():
     try:
         expect(RuntimeError('Something Wrong')).to_be_an_error_like(ValueError)
     except AssertionError:
         return
 
     assert False, 'Should not have gotten this far'
+
+
+def test_not_to_be_an_error_like():
+    expect('Something Wrong').Not.to_be_an_error_like(ValueError)
 
 
 def test_not_to_have_error_message():


### PR DESCRIPTION
This pull request solve expectations like "expect(ValueError()).Not.to_be_an_error_like(RuntimeError)".
The last version throw a KeyError (KeyError: 'not_to_be_an_error_like') on expectations like these.
