### PR TITLE
Fixed: Preggy raise an exception when trying to asset binary data in Python 3

### DIFF
--- a/preggy/utils.py
+++ b/preggy/utils.py
@@ -48,7 +48,7 @@ def fix_string(obj):
         try:
             return obj.decode('utf-8')
         except Exception:
-            return unidecode(obj)
+            return obj
     return obj
 
 

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -13,6 +13,8 @@ from preggy import expect
 
 TEST_DATA = (
     'qwe',
+    b'qwe',
+    b'\xff\xd8\xff\xe0\x00\x10JFIF',
     [1],
     {'a': 'b'},
     tuple([2])


### PR DESCRIPTION
When to_equal is used to compare file bytes data, it raise an error.
This patch fix this error.
# Traceback:
## ERROR: test_can_get_repository_contents_of_a_image (tests.test_client.TestGandalfClient)

Traceback (most recent call last):
  File "/Users/rafaelsilva/workspace/python/gandalf-client/tests/test_client.py", line 291, in test_can_get_repository_contents_of_a_image
    expect(content).to_equal(img_file.read())
  File "/Users/rafaelsilva/workspace/python/preggy/preggy/core.py", line 229, in _assert_topic
    return _registered_assertions[method_name](self.topic, *args, **kw)
  File "/Users/rafaelsilva/workspace/python/preggy/preggy/core.py", line 59, in wrapper
    return func(_args, *_kw)
  File "/Users/rafaelsilva/workspace/python/preggy/preggy/core.py", line 126, in test_assertion
    if not func(*args):
  File "/Users/rafaelsilva/workspace/python/preggy/preggy/assertions/equality.py", line 22, in to_equal
    topic = utils.fix_string(topic)
  File "/Users/rafaelsilva/workspace/python/preggy/preggy/utils.py", line 57, in fix_string
    return unidecode(obj)
  File "/Users/rafaelsilva/workspace/python/preggy/preggy/.tox/py34/lib/python3.4/site-packages/unidecode/__init__.py", line 38, in unidecode
    codepoint = ord(char)
nose.proxy.TypeError: ord() expected string of length 1, but int found
