### PR TITLE
Support chained assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,17 @@ Failure
 expect.not_to_be_here()  # raises AssertionError
 ```
 
+Chained Assertions
+------------------
+
+```python
+# assertions may be chained, for brevity:
+expect(6).not_to_be_null().to_equal(6)
+
+# a more *sensible* example:
+expect(foo).not_to_be_null().to_equal(expected.get('foo'))
+```
+
 
 Contributing
 ============

--- a/preggy/core.py
+++ b/preggy/core.py
@@ -56,7 +56,8 @@ def assertion(func):
         
     @functools.wraps(func)
     def wrapper(*args, **kw):
-        return func(*args, **kw)
+        func(*args, **kw)
+        return Expect(args[0])
 
     _registered_assertions[wrapper.__name__] = wrapper
     return wrapper
@@ -125,13 +126,15 @@ def create_assertions(func):
             raw_msg = utils.format_assertion_msg(func.humanized, *args)
             err_msg = raw_msg.format(*args)
             raise AssertionError(err_msg)
-    
+        return Expect(args[0])
+
     # Second assertion: prepare
     def test_not_assertion(*args):
         if func(*args):
             raw_msg = utils.format_assertion_msg('not {0!s}'.format(func.humanized), *args)
             err_msg = raw_msg.format(*args)
             raise AssertionError(err_msg)
+        return Expect(args[0])
 
     # Second assertion: update and register
     test_not_assertion = _update_wrapper(test_not_assertion, func)

--- a/tests/test_chaining.py
+++ b/tests/test_chaining.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# preggy assertions
+# https://github.com/heynemann/preggy
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2014 Pablo Santiago Blum de Aguiar <scorphus@gmail.com>
+
+from preggy import expect
+
+
+def test_chaining():
+    expect('qwe') \
+        .not_to_be_null() \
+        .to_be_instance_of(str) \
+        .to_be_like('QWE') \
+        .to_equal('qwe')
+    expect(1729) \
+        .not_to_be_null() \
+        .to_be_instance_of(int) \
+        .to_be_numeric() \
+        .to_be_greater_or_equal_to(496) \
+        .to_equal(1729)
+    expect(3.14159265358979) \
+        .not_to_be_null() \
+        .to_be_instance_of(float) \
+        .to_be_numeric() \
+        .to_be_lesser_or_equal_to(3.1416) \
+        .to_be_like(3.14159265358979)
+    expect([1, 2, 3]) \
+        .not_to_be_null() \
+        .not_to_be_empty() \
+        .to_be_instance_of(list) \
+        .to_be_like([3, 2, 1])
+    expect({'a': 'b', 'x': 'z'}) \
+        .not_to_be_null() \
+        .not_to_be_empty() \
+        .to_be_instance_of(dict) \
+        .to_be_like({'x': 'z', 'a': 'b'})
+
+    meaning = {'x': 42}
+    of_life = {'x': 42}
+
+    expect(meaning.get('y')).to_equal(of_life.get('y'))
+    expect(meaning.get('x')).not_to_be_null().to_equal(of_life.get('x'))
+    try:
+        expect(meaning.get('y')).not_to_be_null().to_equal(of_life.get('x'))
+    except AssertionError:
+        return
+    else:
+        assert False, 'Should not have gotten this far'


### PR DESCRIPTION
Allows one to make chained, briefer assertions, such as:

```
expect(foo).not_to_be_null().to_equal(expected.get('foo'))
```

Instead of:

```
expect(foo).not_to_be_null()
expect(foo).to_equal(expected.get('foo'))
```
