### PR TITLE
fix(assertions.types.classes): bypass exceptions raised by comparison

### DIFF
--- a/preggy/assertions/types/classes.py
+++ b/preggy/assertions/types/classes.py
@@ -18,11 +18,14 @@ from preggy import assertion
 @assertion
 def to_be_instance_of(topic, expected):
     '''Asserts that `topic` is an instance of `expected`.'''
-    TRUE_CONDITIONS = (
-        topic == expected,
+    TRUE_CONDITIONS = [
         isinstance(topic, expected),
         (inspect.isclass(topic) and inspect.isclass(expected)) and issubclass(topic, expected),
-    )
+    ]
+    try:
+        TRUE_CONDITIONS.append(topic == expected)
+    except:
+        pass
     if any(TRUE_CONDITIONS):
         return True
     msg = 'Expected topic({0}) to be an instance of {1}, but it was a {2}'.format(

--- a/tests/types/test_classes.py
+++ b/tests/types/test_classes.py
@@ -13,13 +13,19 @@ from preggy import expect
 
 class FakeClass(object): pass
 class Other(FakeClass):  pass
+class Another(FakeClass):
+    foo = 'bar'
+    def __cmp__(self, other):
+        return cmp(self.foo, other.foo)
 
 
 TEST_DATA = frozenset([
     FakeClass,
     FakeClass(),
     Other,
-    Other()
+    Other(),
+    Another,
+    Another(),
 ])
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Ignore exceptions casually raised by a “[rich comparison](https://docs.python.org/2/reference/datamodel.html#object.__lt__)”.