### PR TITLE
Bugfix (assertion.inclusion): Dict like data can't be compared without an 'in' comparator

### DIFF
--- a/preggy/__meta__.py
+++ b/preggy/__meta__.py
@@ -18,8 +18,8 @@ from datetime import date
 #   GENERAL
 #--------------------------------------------------------------------------------
 __name__        = 'preggy'  # normally preggy.__meta__
-__version__     = '1.3.0'
-__date__        = date(2016, 3, 22)  # TODO: auto-populate each release using a git hook
+__version__     = '1.3.1'
+__date__        = date(2016, 4, 1)  # TODO: auto-populate each release using a git hook
 __keywords__    = 'test testing assert assertion library development'
 __status__      = 'Production'
 

--- a/preggy/assertions/inclusion.py
+++ b/preggy/assertions/inclusion.py
@@ -26,10 +26,13 @@ def to_include(topic, expected):
     '''Asserts that `expected` is in `topic`.'''
     if isinstance(topic, six.string_types + tuple([six.binary_type, six.text_type])):
         return str(expected) in topic
-    for t in topic:
-        try:
-            if expected == t:
-                return True
-        except:
-            pass
-    return False
+    try:
+        return expected in topic
+    except:
+        for t in topic:
+            try:
+                if expected == t:
+                    return True
+            except:
+                pass
+        return False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,3 +59,17 @@ class AnotherComparable(object):
 
     def __cmp__(self, other):
         return cmp(self.baz, other.baz)
+
+
+class DictLike(object):
+
+    def __init__(self, data=None):
+        if data is None:
+            data = {}
+        self.data = data
+
+    def __contains__(self, key):
+        return key in self.data
+
+    def __getitem__(self, key):
+        return self.data[key]

--- a/tests/test_inclusion.py
+++ b/tests/test_inclusion.py
@@ -9,7 +9,7 @@
 
 from preggy import expect
 
-from tests import Comparable
+from tests import Comparable, DictLike
 
 #-----------------------------------------------------------------------------
 
@@ -20,7 +20,8 @@ TEST_DATA = (
     tuple([1, 2, 3]),
     '123',
     '3.14',
-    (None, Comparable(), 'deliberately the last one')
+    (None, Comparable(), 'deliberately the last one'),
+    DictLike({'foo': 'bar'})
 )
 
 INCLUDED_DATA = (
@@ -30,7 +31,8 @@ INCLUDED_DATA = (
     2,
     1,
     3.1,
-    'deliberately the last one'
+    'deliberately the last one',
+    'foo'
 )
 
 NOT_INCLUDED_DATA = (
@@ -40,7 +42,8 @@ NOT_INCLUDED_DATA = (
     5,
     4,
     4.2,
-    2.718281828
+    2.718281828,
+    'bar'
 )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
"to_include" assertion needs to compare as "in comparator" for most cases. Exceptions needs to be comparable as "for in".